### PR TITLE
Array support

### DIFF
--- a/lib/encoding_dot_com/format.rb
+++ b/lib/encoding_dot_com/format.rb
@@ -74,7 +74,7 @@ module EncodingDotCom
             value = output_value(key, value)
             if value.kind_of?(Hash)
               build_node builder, key, value
-            # if the value is an array, loop through the array and add an xml node for each value
+            # if the value is an array, loop through the array and add an xml node of the same key name for each value
             elsif value.kind_of?(Array)
               value.each do |v|
                 builder.send("#{key}_", v) unless v.nil?

--- a/lib/encoding_dot_com/format.rb
+++ b/lib/encoding_dot_com/format.rb
@@ -77,7 +77,11 @@ module EncodingDotCom
             # if the value is an array, loop through the array and add an xml node of the same key name for each value
             elsif value.kind_of?(Array)
               value.each do |v|
-                builder.send("#{key}_", v) unless v.nil?
+                if v.kind_of?(Hash) || v.kind_of?(Array)
+                  build_node builder, key, v
+                else
+                  builder.send("#{key}_", v) unless v.nil?
+                end
               end
             else
               # adding underscore after the key to force it to be a tag instead of matching nokogiri functions

--- a/lib/encoding_dot_com/format.rb
+++ b/lib/encoding_dot_com/format.rb
@@ -75,8 +75,8 @@ module EncodingDotCom
             if value.kind_of?(Hash)
               build_node builder, key, value
             elsif value.kind_of?(Array)
-              value.each do |value|
-                builder.send("#{key}_", value) unless value.nil?
+              value.each do |v|
+                builder.send("#{key}_", v) unless v.nil?
               end
             else
               # adding underscore after the key to force it to be a tag instead of matching nokogiri functions

--- a/lib/encoding_dot_com/format.rb
+++ b/lib/encoding_dot_com/format.rb
@@ -74,7 +74,7 @@ module EncodingDotCom
             value = output_value(key, value)
             if value.kind_of?(Hash)
               build_node builder, key, value
-            # if the value is an array, loop through the array and add an xml node of the same key name for each value
+            # if the value is an array, loop through the array and process each item based on its type
             elsif value.kind_of?(Array)
               value.each do |v|
                 if v.kind_of?(Hash) || v.kind_of?(Array)

--- a/lib/encoding_dot_com/format.rb
+++ b/lib/encoding_dot_com/format.rb
@@ -72,7 +72,11 @@ module EncodingDotCom
           if self.class.allowed_attributes.include? key.to_s
             #if the value is a hash, recursivley call this function until the xml is properly built
             value = output_value(key, value)
-            if value.kind_of?(Hash)
+            if value.kind_of?(Array)
+              value.each do |value|
+                build_node builder, key, value
+              end
+            elsif value.kind_of?(Hash)
               build_node builder, key, value
             else
               # adding underscore after the key to force it to be a tag instead of matching nokogiri functions

--- a/lib/encoding_dot_com/format.rb
+++ b/lib/encoding_dot_com/format.rb
@@ -74,7 +74,7 @@ module EncodingDotCom
             value = output_value(key, value)
             if value.kind_of?(Array)
               value.each do |value|
-                build_node builder, key, value
+                builder.send("#{key}_", value) unless value.nil?
               end
             elsif value.kind_of?(Hash)
               build_node builder, key, value

--- a/lib/encoding_dot_com/format.rb
+++ b/lib/encoding_dot_com/format.rb
@@ -74,6 +74,7 @@ module EncodingDotCom
             value = output_value(key, value)
             if value.kind_of?(Hash)
               build_node builder, key, value
+            # if the value is an array, loop through the array and add an xml node for each value
             elsif value.kind_of?(Array)
               value.each do |v|
                 builder.send("#{key}_", v) unless v.nil?

--- a/lib/encoding_dot_com/format.rb
+++ b/lib/encoding_dot_com/format.rb
@@ -72,12 +72,12 @@ module EncodingDotCom
           if self.class.allowed_attributes.include? key.to_s
             #if the value is a hash, recursivley call this function until the xml is properly built
             value = output_value(key, value)
-            if value.kind_of?(Array)
+            if value.kind_of?(Hash)
+              build_node builder, key, value
+            elsif value.kind_of?(Array)
               value.each do |value|
                 builder.send("#{key}_", value) unless value.nil?
               end
-            elsif value.kind_of?(Hash)
-              build_node builder, key, value
             else
               # adding underscore after the key to force it to be a tag instead of matching nokogiri functions
               builder.send("#{key}_", value) unless value.nil?

--- a/spec/format_spec.rb
+++ b/spec/format_spec.rb
@@ -173,4 +173,14 @@ describe "Encoding.com video format" do
       ExampleFormat4.boolean_attributes.should == ["foo"]
     end
   end
+
+  describe 'setting array attributes on a format' do
+    it 'should create an array attibute' do
+      format = EncodingDotCom::VideoFormat.new('output' => 'wmv', 'audio_stream' => ['', '']) 
+      binding.pry
+      Nokogiri::XML::Builder.new do |b|
+        format.build_xml(b)
+      end.to_xml.should have_xpath('/format/audio_stream')
+    end
+  end
 end

--- a/spec/format_spec.rb
+++ b/spec/format_spec.rb
@@ -180,9 +180,12 @@ describe "Encoding.com video format" do
         'output' => 'wmv',
         'audio_stream' => ['', '']
       )
-      Nokogiri::XML::Builder.new do |b|
+      content = Nokogiri::XML::Builder.new do |b|
         format.build_xml(b)
-      end.to_xml.should have_xpath('/format/audio_stream')
+      end.to_xml
+
+      content.should have_xpath('/format/audio_stream')
+      Nokogiri::XML(content).xpath('/format/audio_stream').count.should be(2)
     end
   end
 end

--- a/spec/format_spec.rb
+++ b/spec/format_spec.rb
@@ -175,7 +175,7 @@ describe "Encoding.com video format" do
   end
 
   describe 'setting array attributes on a format' do
-    it 'should create an array attibute' do
+    it 'should create multiple nodes from key name' do
       format = EncodingDotCom::VideoFormat.new(
         'output' => 'wmv',
         'audio_stream' => ['', '']

--- a/spec/format_spec.rb
+++ b/spec/format_spec.rb
@@ -175,7 +175,7 @@ describe "Encoding.com video format" do
   end
 
   describe 'setting array attributes on a format' do
-    it 'should create multiple nodes from key name' do
+    it 'should create multiple nodes from key name for each value' do
       format = EncodingDotCom::VideoFormat.new(
         'output' => 'wmv',
         'audio_stream' => ['', '']

--- a/spec/format_spec.rb
+++ b/spec/format_spec.rb
@@ -187,17 +187,19 @@ describe "Encoding.com video format" do
       Nokogiri::XML(content).xpath('/format/audio_stream').count.should be(2)
     end
 
-    it 'should create multiple nodes from key name for each value' do
+    it 'should create nested nodes from hash in an array' do
       format = EncodingDotCom::VideoFormat.new(
         'output' => 'wmv',
         'audio_stream' => [
           {'language' => 'eng', 'use_stream_id' => '1'}
         ]
       )
-      content = Nokogiri::XML::Builder.new do |b|
+      xml = Nokogiri::XML::Builder.new do |b|
         format.build_xml(b)
       end.to_xml
-      Nokogiri::XML(content).xpath('/format/audio_stream').count.should be(2)
+
+      xml.should have_xpath('/format/audio_stream/language[text()="eng"]')
+      xml.should have_xpath('/format/audio_stream/use_stream_id[text()="1"]')
     end
   end
 end

--- a/spec/format_spec.rb
+++ b/spec/format_spec.rb
@@ -184,7 +184,6 @@ describe "Encoding.com video format" do
         format.build_xml(b)
       end.to_xml
 
-      content.should have_xpath('/format/audio_stream')
       Nokogiri::XML(content).xpath('/format/audio_stream').count.should be(2)
     end
   end

--- a/spec/format_spec.rb
+++ b/spec/format_spec.rb
@@ -176,8 +176,10 @@ describe "Encoding.com video format" do
 
   describe 'setting array attributes on a format' do
     it 'should create an array attibute' do
-      format = EncodingDotCom::VideoFormat.new('output' => 'wmv', 'audio_stream' => ['', '']) 
-      binding.pry
+      format = EncodingDotCom::VideoFormat.new(
+        'output' => 'wmv',
+        'audio_stream' => ['', '']
+      )
       Nokogiri::XML::Builder.new do |b|
         format.build_xml(b)
       end.to_xml.should have_xpath('/format/audio_stream')

--- a/spec/format_spec.rb
+++ b/spec/format_spec.rb
@@ -180,11 +180,11 @@ describe "Encoding.com video format" do
         'output' => 'wmv',
         'audio_stream' => ['', '']
       )
-      content = Nokogiri::XML::Builder.new do |b|
+      xml = Nokogiri::XML::Builder.new do |b|
         format.build_xml(b)
       end.to_xml
 
-      Nokogiri::XML(content).xpath('/format/audio_stream').count.should be(2)
+      Nokogiri::XML(xml).xpath('/format/audio_stream').count.should be(2)
     end
 
     it 'should create nested nodes from hash in an array' do

--- a/spec/format_spec.rb
+++ b/spec/format_spec.rb
@@ -186,5 +186,18 @@ describe "Encoding.com video format" do
 
       Nokogiri::XML(content).xpath('/format/audio_stream').count.should be(2)
     end
+
+    it 'should create multiple nodes from key name for each value' do
+      format = EncodingDotCom::VideoFormat.new(
+        'output' => 'wmv',
+        'audio_stream' => [
+          {'language' => 'eng', 'use_stream_id' => '1'}
+        ]
+      )
+      content = Nokogiri::XML::Builder.new do |b|
+        format.build_xml(b)
+      end.to_xml
+      Nokogiri::XML(content).xpath('/format/audio_stream').count.should be(2)
+    end
   end
 end


### PR DESCRIPTION
**What does this PR do?**
Adds support for attributes of `format` being an array.  The array can contain values, arrays, or hashes.  